### PR TITLE
Implement VOOG intro overlay targets

### DIFF
--- a/components/edicy-tools-variables.tpl
+++ b/components/edicy-tools-variables.tpl
@@ -616,4 +616,10 @@
       }
     ]
   {% endcapture %}
+
+  {% comment %}VOOG intro popover targets. Add them where applicable popovers should appear.{% endcomment %}
+  {% capture edy_intro_add_page %}{% if editmode %}data-edy-intro-popover="edy-add-page"{% endif %}{% endcapture %}
+  {% capture edy_intro_add_lang %}{% if editmode %}data-edy-intro-popover="edy-add-lang"{% endif %}{% endcapture %}
+  {% capture edy_intro_edit_text %}{% if editmode %}data-edy-intro-popover="edy-edit-text"{% endif %}{% endcapture %}
+
 {% endcapture %}

--- a/components/header.tpl
+++ b/components/header.tpl
@@ -46,8 +46,8 @@
 
       {% unless front_page %}
         {% if editmode or site.has_many_languages? %}
-          <nav class="menu-lang inline js-menu-lang {% if flags_state %}flags-enabled{% else %}flags-disabled{% endif %}" {{ edy_intro_add_lang }}>
-            <button class="menu-lang-btn js-menu-lang-btn lang-flag lang-flag-{{ page.language_code }}" data-lang-code="{{ page.language_code }}">
+          <nav class="menu-lang inline js-menu-lang {% if flags_state %}flags-enabled{% else %}flags-disabled{% endif %}">
+            <button class="menu-lang-btn js-menu-lang-btn lang-flag lang-flag-{{ page.language_code }}" data-lang-code="{{ page.language_code }}" {{ edy_intro_add_lang }}>
               {% if editmode or flags_state == false %}
                 <span class="lang-title">
                   {% for language in site.languages %}{% if language.selected? %}{{ language.title }}{% endif %}{% endfor %}

--- a/components/header.tpl
+++ b/components/header.tpl
@@ -46,7 +46,7 @@
 
       {% unless front_page %}
         {% if editmode or site.has_many_languages? %}
-          <nav class="menu-lang inline js-menu-lang {% if flags_state %}flags-enabled{% else %}flags-disabled{% endif %}">
+          <nav class="menu-lang inline js-menu-lang {% if flags_state %}flags-enabled{% else %}flags-disabled{% endif %}" {{ edy_intro_add_lang }}>
             <button class="menu-lang-btn js-menu-lang-btn lang-flag lang-flag-{{ page.language_code }}" data-lang-code="{{ page.language_code }}">
               {% if editmode or flags_state == false %}
                 <span class="lang-title">

--- a/components/menu-level-1.tpl
+++ b/components/menu-level-1.tpl
@@ -46,8 +46,8 @@
 
     {% if editmode or site.has_many_languages? %}
       <li class="menu-item menu-item-lang-inline">
-        <nav class="menu-lang inline js-menu-lang {% if flags_state %}flags-enabled{% else %}flags-disabled{% endif %}" {{ edy_intro_add_lang }}>
-          <button class="menu-lang-btn js-menu-lang-btn lang-flag lang-flag-{{ page.language_code }}" data-lang-code="{{ page.language_code }}">
+        <nav class="menu-lang inline js-menu-lang {% if flags_state %}flags-enabled{% else %}flags-disabled{% endif %}">
+          <button class="menu-lang-btn js-menu-lang-btn lang-flag lang-flag-{{ page.language_code }}" data-lang-code="{{ page.language_code }}" {{ edy_intro_add_lang }}>
             {% if editmode or flags_state == false %}
               <span class="lang-title">
                 {% for language in site.languages %}{% if language.selected? %}{{ language.title }}{% endif %}{% endfor %}

--- a/components/menu-level-1.tpl
+++ b/components/menu-level-1.tpl
@@ -18,7 +18,7 @@
       <li class="edit-btn">{% menubtn site.hidden_menuitems %}</li>
     {% endif %}
 
-    <li class="edit-btn right-mainmenu">{% menuadd %}</li>
+    <li class="edit-btn right-mainmenu" {{ edy_intro_add_page }}>{% menuadd %}</li>
   {% endif %}
 </ul>
 
@@ -46,7 +46,7 @@
 
     {% if editmode or site.has_many_languages? %}
       <li class="menu-item menu-item-lang-inline">
-        <nav class="menu-lang inline js-menu-lang {% if flags_state %}flags-enabled{% else %}flags-disabled{% endif %}">
+        <nav class="menu-lang inline js-menu-lang {% if flags_state %}flags-enabled{% else %}flags-disabled{% endif %}" {{ edy_intro_add_lang }}>
           <button class="menu-lang-btn js-menu-lang-btn lang-flag lang-flag-{{ page.language_code }}" data-lang-code="{{ page.language_code }}">
             {% if editmode or flags_state == false %}
               <span class="lang-title">

--- a/layouts/blog_article.tpl
+++ b/layouts/blog_article.tpl
@@ -23,8 +23,8 @@
           </header>
 
           <section class="post-content">
-            <div class="post-excerpt content-formatted">{% editable article.excerpt %}</div>
-            <div class="post-body content-formatted" {{ edy_intro_edit_text }}>{% editable article.body %}</div>
+            <div class="post-excerpt content-formatted" {{ edy_intro_edit_text }}>{% editable article.excerpt %}</div>
+            <div class="post-body content-formatted">{% editable article.body %}</div>
           </section>
         </article>
 

--- a/layouts/blog_article.tpl
+++ b/layouts/blog_article.tpl
@@ -24,7 +24,7 @@
 
           <section class="post-content">
             <div class="post-excerpt content-formatted">{% editable article.excerpt %}</div>
-            <div class="post-body content-formatted">{% editable article.body %}</div>
+            <div class="post-body content-formatted" {{ edy_intro_edit_text }}>{% editable article.body %}</div>
           </section>
         </article>
 

--- a/layouts/common_page.tpl
+++ b/layouts/common_page.tpl
@@ -12,7 +12,7 @@
 
     <main class="content" role="main">
       <div class="content-inner{% if has_children %} with-submenu{% endif %}">
-        <section class="content-body content-formatted">{% content %}</section>
+        <section class="content-body content-formatted" {{ edy_intro_edit_text }}>{% content %}</section>
       </div>
     </main>
 

--- a/layouts/front_page.tpl
+++ b/layouts/front_page.tpl
@@ -22,7 +22,7 @@
         {% endif %}
 
         <div class="content-inner js-background-type {{ main_bg_type }}">
-          <section class="content-body content-formatted" data-search-indexing-allowed="true">{% content %}</section>
+          <section class="content-body content-formatted" data-search-indexing-allowed="true" {{ edy_intro_edit_text }}>{% content %}</section>
         </div>
       </div>
     </main>


### PR DESCRIPTION
Current targetable areas are:

```
data-edy-intro-popover="edy-add-page"
data-edy-intro-popover="edy-add-lang"
data-edy-intro-popover="edy-edit-text"
```
